### PR TITLE
Fix wave overlay in new-app

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -3910,7 +3910,8 @@ label.has-value {
     }
    
     .equip .bg-bottom2 {
-     top: 93%;
+        top: 98%;
+        z-index: 1000;
     }
 
     .equip-buttons2 {

--- a/docs/components/new_app.js
+++ b/docs/components/new_app.js
@@ -3,7 +3,7 @@ equipCompanyTemplate2.innerHTML = `
 <section class="equip company-equip">
             <img src="assets/img/custom-bg-2.svg" alt="" class="custom-bg">
             <img src="assets/img/bg-top-1.svg" alt="" class="bg-top">
-            <img src="assets/img/whiteWave.svg" alt="" class="bg-bottom bg-bottom2" style="z-index: 999">
+            <img src="assets/img/whiteWave.svg" alt="" class="bg-bottom bg-bottom2" style="z-index: 1000">
             <div class="container">
                 <div class="block-left">
                     <h2 class="section-title-app">NEW<h1>
@@ -31,7 +31,7 @@ equipCompanyTemplate2.innerHTML = `
                 </div>
 
                 <div class="block-right block-right2" style=" display: flex;justify-content: center; margin-top: 60px">
-                <img src="assets/img/icons/screens.png" alt="" style="height: 100%; ">
+                <img src="assets/img/icons/screens.png" alt="Mobile app screens" style="height: 130%; margin-top: 20px;">
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- adjust z-index for bottom wave overlay
- reposition wave in CSS to sit over page elements

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688bdb62a7dc8332a326f435c51f7cb7