### PR TITLE
Update to jQuery 3.7.1

### DIFF
--- a/docs/cokie.html
+++ b/docs/cokie.html
@@ -47,8 +47,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/company.html
+++ b/docs/company.html
@@ -339,8 +339,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/dataremove.html
+++ b/docs/dataremove.html
@@ -44,8 +44,7 @@
 
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/do_not_sell_my_info.html
+++ b/docs/do_not_sell_my_info.html
@@ -47,8 +47,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/e-commerce.html
+++ b/docs/e-commerce.html
@@ -47,8 +47,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/employerConfirm.html
+++ b/docs/employerConfirm.html
@@ -58,8 +58,7 @@
         <bottom-menu></bottom-menu>
     </div>
 
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/h-bars.html
+++ b/docs/h-bars.html
@@ -57,8 +57,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/h-casual.html
+++ b/docs/h-casual.html
@@ -61,8 +61,7 @@
     
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/h-coffee.html
+++ b/docs/h-coffee.html
@@ -62,8 +62,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/h-fine.html
+++ b/docs/h-fine.html
@@ -59,8 +59,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/h-quick.html
+++ b/docs/h-quick.html
@@ -59,8 +59,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/h-truck.html
+++ b/docs/h-truck.html
@@ -61,8 +61,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/hardware.html
+++ b/docs/hardware.html
@@ -69,8 +69,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -23,8 +23,7 @@
     <link rel="stylesheet" href="assets/css/burger.css" />
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
 
     <!-- Define custom components -->

--- a/docs/legal.html
+++ b/docs/legal.html
@@ -47,8 +47,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/merchant.html
+++ b/docs/merchant.html
@@ -47,8 +47,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/payment_processing.html
+++ b/docs/payment_processing.html
@@ -128,8 +128,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -53,8 +53,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -252,8 +252,7 @@
 
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/r-clothing.html
+++ b/docs/r-clothing.html
@@ -61,8 +61,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/r-grocery.html
+++ b/docs/r-grocery.html
@@ -63,8 +63,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/r-liquor.html
+++ b/docs/r-liquor.html
@@ -73,8 +73,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/r-specialty.html
+++ b/docs/r-specialty.html
@@ -60,8 +60,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/restaurant.html
+++ b/docs/restaurant.html
@@ -71,8 +71,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/retail.html
+++ b/docs/retail.html
@@ -65,8 +65,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/software.html
+++ b/docs/software.html
@@ -101,8 +101,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -47,8 +47,7 @@
     </div>
     <script src="https://unpkg.com/imask"></script>
     <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-1.11.0.min.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="assets/slick/slick.min.js"></script>
     <script src="assets/js/more.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- update jQuery on all HTML pages to 3.7.1
- drop old jquery-migrate script

## Testing
- `grep -R "jquery-3.7.1.min.js" -l docs | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_688d05cb30f48332a3c920649cbca712