### PR TITLE
Fix page loading by deferring scripts

### DIFF
--- a/docs/cokie.html
+++ b/docs/cokie.html
@@ -29,16 +29,16 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css">
     <link rel="stylesheet" href="assets/css/burger.css">
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/faq.js"></script>
-    <script src="components/tariff_cards.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/type_cards.js"></script>
-    <script src="components/hardware_cards.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/pricing_advantages.js"></script>
-    <script src="components/our_products.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/faq.js"></script>
+    <script defer src="components/tariff_cards.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/type_cards.js"></script>
+    <script defer src="components/hardware_cards.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/pricing_advantages.js"></script>
+    <script defer src="components/our_products.js"></script>
     <style>
         .tariff-card .price-off {
             display: none
@@ -54,11 +54,11 @@
         </center>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/company.html
+++ b/docs/company.html
@@ -29,13 +29,13 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css" />
     <link rel="stylesheet" href="assets/css/burger.css" />
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/our_products.js"></script>
-    <script src="components/company_form.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/our_products_company.js"></script>
-    <script src="components/tech_stack.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/our_products.js"></script>
+    <script defer src="components/company_form.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/our_products_company.js"></script>
+    <script defer src="components/tech_stack.js"></script>
 </head>
 
 <body>
@@ -346,11 +346,11 @@
     <div style="margin-top:-150px;" class="on-mobile"></div>
     <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/dataremove.html
+++ b/docs/dataremove.html
@@ -28,9 +28,9 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css">
     <link rel="stylesheet" href="assets/css/burger.css">
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/faq.js"></script>
-    <script src="components/bottom_menu.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/faq.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
 </head>
 
 <body>
@@ -51,11 +51,11 @@
     </div>
     
 
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/do_not_sell_my_info.html
+++ b/docs/do_not_sell_my_info.html
@@ -29,16 +29,16 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css">
     <link rel="stylesheet" href="assets/css/burger.css">
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/faq.js"></script>
-    <script src="components/tariff_cards.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/type_cards.js"></script>
-    <script src="components/hardware_cards.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/pricing_advantages.js"></script>
-    <script src="components/our_products.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/faq.js"></script>
+    <script defer src="components/tariff_cards.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/type_cards.js"></script>
+    <script defer src="components/hardware_cards.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/pricing_advantages.js"></script>
+    <script defer src="components/our_products.js"></script>
     <style>
         .tariff-card .price-off {
             display: none
@@ -54,11 +54,11 @@
         </center>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/e-commerce.html
+++ b/docs/e-commerce.html
@@ -29,16 +29,16 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css">
     <link rel="stylesheet" href="assets/css/burger.css">
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/faq.js"></script>
-    <script src="components/tariff_cards.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/type_cards.js"></script>
-    <script src="components/hardware_cards.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/pricing_advantages.js"></script>
-    <script src="components/our_products.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/faq.js"></script>
+    <script defer src="components/tariff_cards.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/type_cards.js"></script>
+    <script defer src="components/hardware_cards.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/pricing_advantages.js"></script>
+    <script defer src="components/our_products.js"></script>
     <style>
         .tariff-card .price-off {
             display: none
@@ -54,11 +54,11 @@
         </center>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/employerConfirm.html
+++ b/docs/employerConfirm.html
@@ -29,10 +29,10 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css">
     <link rel="stylesheet" href="assets/css/burger.css">
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/h_employer-confirm.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/h_employer-confirm.js"></script>
     <style>
         .equipBottomDiv {
             height: 100px;
@@ -67,9 +67,9 @@
         <bottom-menu></bottom-menu>
     </div>
 
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/h-bars.html
+++ b/docs/h-bars.html
@@ -30,12 +30,12 @@
     <link rel="stylesheet" href="assets/css/burger.css">
 
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/h_advantages.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/bottom_menu.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/h_advantages.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
 </head>
 
 <body>
@@ -63,11 +63,11 @@
         <pricing-form></pricing-form>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/h-casual.html
+++ b/docs/h-casual.html
@@ -30,12 +30,12 @@
     <link rel="stylesheet" href="assets/css/burger.css">
 
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/h_advantages.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/bottom_menu.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/h_advantages.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
 </head>
 
 <body>
@@ -67,11 +67,11 @@
         <bottom-menu></bottom-menu>
     </div>
     
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/h-coffee.html
+++ b/docs/h-coffee.html
@@ -30,12 +30,12 @@
     <link rel="stylesheet" href="assets/css/burger.css">
 
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/h_advantages.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/bottom_menu.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/h_advantages.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
 </head>
 
 <body>
@@ -68,11 +68,11 @@
         <pricing-form></pricing-form>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/h-fine.html
+++ b/docs/h-fine.html
@@ -30,12 +30,12 @@
     <link rel="stylesheet" href="assets/css/burger.css">
 
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/h_advantages.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/bottom_menu.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/h_advantages.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
 </head>
 
 <body>
@@ -65,11 +65,11 @@
         <bottom-menu></bottom-menu>
         
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/h-quick.html
+++ b/docs/h-quick.html
@@ -30,12 +30,12 @@
     <link rel="stylesheet" href="assets/css/burger.css">
 
      <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/h_advantages.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/bottom_menu.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/h_advantages.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
 </head>
 
 <body>
@@ -65,11 +65,11 @@
         <pricing-form></pricing-form>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/h-truck.html
+++ b/docs/h-truck.html
@@ -30,12 +30,12 @@
     <link rel="stylesheet" href="assets/css/burger.css">
 
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/h_advantages.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/bottom_menu.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/h_advantages.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
 </head>
 
 <body>
@@ -67,11 +67,11 @@
         <pricing-form></pricing-form>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/hardware.html
+++ b/docs/hardware.html
@@ -31,17 +31,17 @@
     <link rel="stylesheet" href="assets/css/hardware-cards-vertical-slider.css">
 
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/faq-hard.js"></script>
-    <script src="components/h_who_cards.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/tariff_cards.js"></script>
-    <script src="components/hardware_advantages.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/type_cards.js"></script>
-    <script src="components/hardware_cards.js"></script>
-    <script src="components/hardware_something_slider.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/faq-hard.js"></script>
+    <script defer src="components/h_who_cards.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/tariff_cards.js"></script>
+    <script defer src="components/hardware_advantages.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/type_cards.js"></script>
+    <script defer src="components/hardware_cards.js"></script>
+    <script defer src="components/hardware_something_slider.js"></script>
 </head>
 
 <body>
@@ -76,13 +76,13 @@
         <div style="margin-top:-200px;" class="off-mobile"></div>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 
-    <script type="module" src="components/hardware_cards_vertical_slider.js"></script>
+    <script type="module" defer src="components/hardware_cards_vertical_slider.js"></script>
    
 </body>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,19 +30,19 @@
     <title>Slimrate</title>
     <link rel="stylesheet" href="assets/css/style.css" />
     <link rel="stylesheet" href="assets/css/burger.css" />
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
 
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/faq.js"></script>
-    <script src="components/our_products.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/new_app.js"></script>
-    <script src="components/equip_main.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/faq.js"></script>
+    <script defer src="components/our_products.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/new_app.js"></script>
+    <script defer src="components/equip_main.js"></script>
     
     <!-- customerTestimonials -->  
     <link rel="stylesheet" href="components/customerTestimonials/customertestimonials.css">
@@ -136,10 +136,10 @@
     </div>
     
   <!-- customerTestimonials -->  
-  <script src="components/customerTestimonials/customerTestimonials.js"></script>
+  <script defer src="components/customerTestimonials/customerTestimonials.js"></script>
   <!-- minimalSlider-->
-  <script type="module" src="components/minimalSlider/minimalSlider.js"></script>
-  <script src="assets/js/more.js"></script>
+  <script type="module" defer src="components/minimalSlider/minimalSlider.js"></script>
+  <script defer src="assets/js/more.js"></script>
 
 </body>
 

--- a/docs/legal.html
+++ b/docs/legal.html
@@ -29,16 +29,16 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css">
     <link rel="stylesheet" href="assets/css/burger.css">
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/faq.js"></script>
-    <script src="components/tariff_cards.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/type_cards.js"></script>
-    <script src="components/hardware_cards.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/pricing_advantages.js"></script>
-    <script src="components/our_products.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/faq.js"></script>
+    <script defer src="components/tariff_cards.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/type_cards.js"></script>
+    <script defer src="components/hardware_cards.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/pricing_advantages.js"></script>
+    <script defer src="components/our_products.js"></script>
     <style>
         .tariff-card .price-off {
             display: none
@@ -54,11 +54,11 @@
         </center>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/merchant.html
+++ b/docs/merchant.html
@@ -29,16 +29,16 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css">
     <link rel="stylesheet" href="assets/css/burger.css">
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/faq.js"></script>
-    <script src="components/tariff_cards.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/type_cards.js"></script>
-    <script src="components/hardware_cards.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/pricing_advantages.js"></script>
-    <script src="components/our_products.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/faq.js"></script>
+    <script defer src="components/tariff_cards.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/type_cards.js"></script>
+    <script defer src="components/hardware_cards.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/pricing_advantages.js"></script>
+    <script defer src="components/our_products.js"></script>
     <style>
         .tariff-card .price-off {
             display: none
@@ -54,11 +54,11 @@
         </center>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/payment_processing.html
+++ b/docs/payment_processing.html
@@ -30,18 +30,18 @@
     <link rel="stylesheet" href="assets/css/burger.css">
 
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/faq-pp.js"></script>
-    <script src="components/p_who_cards.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/tariff_cards.js"></script>
-    <script src="components/h_advantages.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/type_cards.js"></script>
-    <script src="components/we_support.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/tech_stack.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/faq-pp.js"></script>
+    <script defer src="components/p_who_cards.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/tariff_cards.js"></script>
+    <script defer src="components/h_advantages.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/type_cards.js"></script>
+    <script defer src="components/we_support.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/tech_stack.js"></script>
 </head>
 
 <body>
@@ -135,11 +135,11 @@
         <div style="margin-top:-200px;" class="on-mobile"></div>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/pricing.html
+++ b/docs/pricing.html
@@ -29,15 +29,15 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css">
     <link rel="stylesheet" href="assets/css/burger.css">
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script><script src="components/faq.js"></script>
-    <script src="components/tariff_cards.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/type_cards.js"></script>
-    <script src="components/hardware_cards.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/pricing_advantages.js"></script>
-    <script src="components/our_products.js"></script>
+    <script defer src="components/top_menu.js"></script><script defer src="components/faq.js"></script>
+    <script defer src="components/tariff_cards.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/type_cards.js"></script>
+    <script defer src="components/hardware_cards.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/pricing_advantages.js"></script>
+    <script defer src="components/our_products.js"></script>
     <style>
         .tariff-card .price-off {
             display: none
@@ -60,11 +60,11 @@
         <pricing-form></pricing-form>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -28,9 +28,9 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css">
     <link rel="stylesheet" href="assets/css/burger.css">
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/faq.js"></script>
-    <script src="components/bottom_menu.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/faq.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
 </head>
 
 <body>
@@ -259,11 +259,11 @@
     </div>
     
 
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/r-clothing.html
+++ b/docs/r-clothing.html
@@ -30,12 +30,12 @@
     <link rel="stylesheet" href="assets/css/burger.css">
 
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/h_advantages.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/bottom_menu.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/h_advantages.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
 </head>
 
 <body>
@@ -67,11 +67,11 @@
         <pricing-form></pricing-form>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/r-grocery.html
+++ b/docs/r-grocery.html
@@ -31,12 +31,12 @@
 
 
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/h_advantages.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/bottom_menu.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/h_advantages.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
 </head>
 
 <body>
@@ -69,11 +69,11 @@
         <pricing-form></pricing-form>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/r-liquor.html
+++ b/docs/r-liquor.html
@@ -30,12 +30,12 @@
     <link rel="stylesheet" href="assets/css/burger.css">
     
        <!-- Define custom components -->
-       <script src="components/top_menu.js"></script>
-       <script src="components/h_something_slider.js"></script>
-       <script src="components/equip_company.js"></script>
-       <script src="components/h_advantages.js"></script>
-       <script src="components/pricing_form.js"></script>
-       <script src="components/bottom_menu.js"></script>
+       <script defer src="components/top_menu.js"></script>
+       <script defer src="components/h_something_slider.js"></script>
+       <script defer src="components/equip_company.js"></script>
+       <script defer src="components/h_advantages.js"></script>
+       <script defer src="components/pricing_form.js"></script>
+       <script defer src="components/bottom_menu.js"></script>
 </head>
 
 <body>
@@ -79,11 +79,11 @@
         <pricing-form></pricing-form>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/r-specialty.html
+++ b/docs/r-specialty.html
@@ -30,12 +30,12 @@
     <link rel="stylesheet" href="assets/css/burger.css">
 
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/h_advantages.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/bottom_menu.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/h_advantages.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
 </head>
 
 <body>
@@ -66,11 +66,11 @@
         <pricing-form></pricing-form>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/restaurant.html
+++ b/docs/restaurant.html
@@ -29,15 +29,15 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css">
     <link rel="stylesheet" href="assets/css/burger.css">
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/our_products.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/tariff_cards.js"></script>
-    <script src="components/rest_who_cards.js"></script>
-    <script src="components/h_advantages.js"></script>
-    <script src="components/equip_company.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/our_products.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/tariff_cards.js"></script>
+    <script defer src="components/rest_who_cards.js"></script>
+    <script defer src="components/h_advantages.js"></script>
+    <script defer src="components/equip_company.js"></script>
 </head>
 
 <body>
@@ -77,11 +77,11 @@
         <product-cards></product-cards>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/retail.html
+++ b/docs/retail.html
@@ -28,16 +28,16 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css">
     <link rel="stylesheet" href="assets/css/burger.css">
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/r_something_slider.js"></script>
-    <script src="components/our_products.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/tariff_cards.js"></script>
-    <script src="components/r_who_cards.js"></script>
-    <script src="components/h_advantages.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/type_cards.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/r_something_slider.js"></script>
+    <script defer src="components/our_products.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/tariff_cards.js"></script>
+    <script defer src="components/r_who_cards.js"></script>
+    <script defer src="components/h_advantages.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/type_cards.js"></script>
 </head>
 
 <body>
@@ -72,11 +72,11 @@
         <product-cards></product-cards>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/software.html
+++ b/docs/software.html
@@ -30,15 +30,15 @@
     <link rel="stylesheet" href="assets/css/burger.css">
 
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/faq-soft.js"></script>
-    <script src="components/h_who_cards.js"></script>
-    <script src="components/h_something_slider.js"></script>
-    <script src="components/tariff_cards.js"></script>
-    <script src="components/software_advantages.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/type_cards.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/faq-soft.js"></script>
+    <script defer src="components/h_who_cards.js"></script>
+    <script defer src="components/h_something_slider.js"></script>
+    <script defer src="components/tariff_cards.js"></script>
+    <script defer src="components/software_advantages.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/type_cards.js"></script>
 </head>
 
 <body>
@@ -108,11 +108,11 @@
         <div style="margin-top:-200px;" class="off-mobile"></div>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -29,16 +29,16 @@
     <link rel="stylesheet" href="assets/slick/slick-theme.css">
     <link rel="stylesheet" href="assets/css/burger.css">
     <!-- Define custom components -->
-    <script src="components/top_menu.js"></script>
-    <script src="components/faq.js"></script>
-    <script src="components/tariff_cards.js"></script>
-    <script src="components/bottom_menu.js"></script>
-    <script src="components/pricing_form.js"></script>
-    <script src="components/type_cards.js"></script>
-    <script src="components/hardware_cards.js"></script>
-    <script src="components/equip_company.js"></script>
-    <script src="components/pricing_advantages.js"></script>
-    <script src="components/our_products.js"></script>
+    <script defer src="components/top_menu.js"></script>
+    <script defer src="components/faq.js"></script>
+    <script defer src="components/tariff_cards.js"></script>
+    <script defer src="components/bottom_menu.js"></script>
+    <script defer src="components/pricing_form.js"></script>
+    <script defer src="components/type_cards.js"></script>
+    <script defer src="components/hardware_cards.js"></script>
+    <script defer src="components/equip_company.js"></script>
+    <script defer src="components/pricing_advantages.js"></script>
+    <script defer src="components/our_products.js"></script>
     <style>
         .tariff-card .price-off {
             display: none
@@ -54,11 +54,11 @@
         </center>
         <bottom-menu></bottom-menu>
     </div>
-    <script src="https://unpkg.com/imask"></script>
-    <script src="assets/js/masks.js"></script>
-    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="assets/slick/slick.min.js"></script>
-    <script src="assets/js/more.js"></script>
+    <script defer src="https://unpkg.com/imask"></script>
+    <script defer src="assets/js/masks.js"></script>
+    <script type="text/javascript" defer src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script defer src="assets/slick/slick.min.js"></script>
+    <script defer src="assets/js/more.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- use `defer` on external scripts so they don't block the DOM parser

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d18c857e08332b4998c830b3b633f