### PR TITLE
Fix new-app layout

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -615,7 +615,9 @@ h2.section-title span {
 }
 
 .company-equip {
-   z-index: 1;
+    position: relative;
+    overflow: hidden;
+    z-index: 1;
 }
 
 .company-faq .faq-block__left {
@@ -4033,4 +4035,76 @@ ection.we-support {
   .menu-buttons a {
     display: inline-block;
   }
+
+/* App download section styles */
+.store-buttons {
+    display: flex;
+    gap: 12px;
+    margin-top: 16px;
+}
+
+.store-btn img {
+    height: 48px;
+    display: block;
+}
+
+.phone-wrapper {
+    position: relative;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    z-index: 1;
+}
+
+.phone-wrapper img {
+    max-width: 100%;
+    height: auto;
+    object-fit: contain;
+    z-index: 1;
+}
+
+.wave-overlay {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    z-index: 2;
+    pointer-events: none;
+}
+
+@media screen and (min-width: 992px) {
+    .equip .container {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .block-left {
+        width: 50%;
+    }
+
+    .phone-wrapper {
+        width: 45%;
+        position: relative;
+    }
+}
+
+@media screen and (max-width: 991px) {
+    .equip .container {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+    }
+
+    .block-left {
+        width: 100%;
+        margin-bottom: 20px;
+    }
+
+    .phone-wrapper {
+        width: 85%;
+        max-width: 350px;
+        margin-top: 20px;
+    }
+}
 

--- a/docs/components/new_app.js
+++ b/docs/components/new_app.js
@@ -3,36 +3,29 @@ equipCompanyTemplate2.innerHTML = `
 <section class="equip company-equip">
             <img src="assets/img/custom-bg-2.svg" alt="Slimrate product image" class="custom-bg">
             <img src="assets/img/bg-top-1.svg" alt="Slimrate product image" class="bg-top">
-            <img src="assets/img/whiteWave.svg" alt="Slimrate product image" class="bg-bottom bg-bottom2" style="z-index: 999">
             <div class="container">
                 <div class="block-left">
-                    <h2 class="section-title-app">NEW<h1>
-                    <h2 class="section-title-app" style="margin-bottom: 20px">PRODUCT<h1>
-                    <h2 class="section-title" style="text-align: left">Mobile App <br></h2>
-                    <p class="equip-text" style="text-align: left; font-size: 19px">
+                    <h2 class="section-title-app">NEW<br>PRODUCT</h2>
+                    <h2 class="section-title">Mobile App</h2>
+                    <p class="equip-text">
                         Manage your store from your phone! <br>
                         Convenient management<br>
                         and analysis with Slimrate!
                     </p>
-                    <div class="equip-buttons equip-buttons2" >
-                        <button class="form__btn"  onclick="
-        (function() {
-            var userAgent = navigator.userAgent || navigator.vendor || window.opera;
-            if (/android/i.test(userAgent)) {
-                window.location.href = 'https://play.google.com/store/apps/details?id=com.slimrate.business'; 
-            } else if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
-                window.location.href = 'https://apps.apple.com/us/app/slimrate-business/id6651859534';
-            } else {
-                window.location.href = 'https://play.google.com/store/apps/details?id=com.slimrate.business'; 
-            }
-        })();
-    " >Try NOW!</button>
+                    <div class="store-buttons">
+                      <a class="store-btn" href="https://apps.apple.com/us/app/slimrate-business/id6651859534" target="_blank">
+                        <img src="assets/img/icons/appstore.svg" alt="Download on the App Store">
+                      </a>
+                      <a class="store-btn" href="https://play.google.com/store/apps/details?id=com.slimrate.business" target="_blank">
+                        <img src="assets/img/icons/googleplay.svg" alt="Get it on Google Play">
+                      </a>
                     </div>
                 </div>
 
-                <div class="block-right block-right2" style=" display: flex;justify-content: center; margin-top: 60px">
-                <img src="assets/img/icons/screens.png" alt="Slimrate product image" style="height: 100%; ">
+                <div class="phone-wrapper">
+                    <img src="assets/img/icons/screens.png" alt="Slimrate mobile app preview">
                 </div>
+                <img src="assets/img/whiteWave.svg" class="wave-overlay" alt="">
             </div>
         </section>
 `;


### PR DESCRIPTION
## Summary
- overhaul new-app markup for cleaner headings and download buttons
- add phone wrapper and wave overlay images
- style new-app section for desktop and mobile layouts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688d22b6eae883328a73f96b921e355d