### PR TITLE
Increase cache duration

### DIFF
--- a/docs/service-worker.js
+++ b/docs/service-worker.js
@@ -1,8 +1,8 @@
-const CACHE_NAME = 'slimrate-cache-v2';
+const CACHE_NAME = 'slimrate-cache-v3';
 
 // Time (in milliseconds) to keep cached responses before updating.
-// Currently set to thirty days.
-const CACHE_MAX_AGE = 30 * 24 * 60 * 60 * 1000;
+// Currently set to ninety days.
+const CACHE_MAX_AGE = 90 * 24 * 60 * 60 * 1000;
 
 // Helper to clone a response and attach the current timestamp so we can
 // determine its age later.


### PR DESCRIPTION
## Summary
- extend service worker cache lifetime to ninety days

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688d28d777cc8332880f86b352d76665