### PR TITLE
Add web manifest for Slimrate site

### DIFF
--- a/docs/site.webmanifest
+++ b/docs/site.webmanifest
@@ -1,0 +1,12 @@
+{
+  "name": "Slimrate",
+  "short_name": "Slimrate",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#407AF4",
+  "background_color": "#ffffff",
+  "icons": [
+    { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/android-chrome-256x256.png", "sizes": "256x256", "type": "image/png" }
+  ]
+}


### PR DESCRIPTION
## Summary
- add PWA web manifest for Slimrate site

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f61ea19b08332b991b71c98e5f5ad