### PR TITLE
Add SMS terms for A2P registration

### DIFF
--- a/docs/components/bottom_menu.js
+++ b/docs/components/bottom_menu.js
@@ -31,6 +31,7 @@ bottomMenuTemplate.innerHTML = `
         <ul>
             <li><a href="privacy-policy.html">Privacy Policy</a></li>
             <li><a href="terms.html">Terms of Service</a></li>
+            <li><a href="sms-terms.html">SMS Terms</a></li>
             <li><a href="cookie.html">Cookie Policy</a></li>
             <li><a href="legal.html">Legal</a></li>
             <li><a href="index.html">Copyright © 2024 Slimrate LLC. All rights reserved</a></li>

--- a/docs/sms-terms.html
+++ b/docs/sms-terms.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+<!-- Google tag (gtag.js) with Consent Mode -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-42Y6GNN6DE"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+
+  gtag('consent', 'default', {
+    'analytics_storage': 'denied'
+  });
+
+  gtag('js', new Date());
+  gtag('config', 'G-42Y6GNN6DE');
+</script>
+    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.webp">
+    <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.webp">
+    <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.webp">
+    <link rel="stylesheet" href="https://maxst.icons8.com/vue-static/landings/line-awesome/line-awesome/1.3.0/css/line-awesome.min.css">
+    <link rel="manifest" href="site.webmanifest">
+    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon">
+    <meta charset="UTF-8">
+    <meta name="theme-color" content="#407AF4" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+    <meta name="description" content="Slimrate SMS Terms and Conditions for text message communications."/>
+    <meta name="keywords" content="Slimrate SMS terms, text message terms, POS support SMS"/>
+    <link rel="canonical" href="https://slimrate.com/sms-terms.html"/>
+    <link rel="alternate" hreflang="en" href="https://slimrate.com/sms-terms.html">
+    <link rel="alternate" hreflang="x-default" href="https://slimrate.com/sms-terms.html">
+    <meta property="og:title" content="Slimrate SMS Terms and Conditions"/>
+    <meta property="og:description" content="Terms for Slimrate SMS and text message communications."/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:url" content="https://slimrate.com/sms-terms.html"/>
+    <meta property="og:image" content="https://slimrate.com/apple-touch-icon.webp"/>
+    <meta name="geo.region" content="US"/>
+    <title>Slimrate SMS Terms and Conditions</title>
+    <link rel="stylesheet" href="assets/css/variables.css">
+    <link rel="stylesheet" href="assets/css/base.css">
+    <link rel="stylesheet" href="assets/css/spacing-system.css">
+    <link rel="stylesheet" href="assets/css/header.css">
+    <link rel="stylesheet" href="assets/css/buttons.css">
+    <link rel="stylesheet" href="assets/css/dropdown-menu.css">
+    <link rel="stylesheet" href="assets/css/hero.css">
+    <link rel="stylesheet" href="assets/css/cards.css">
+    <link rel="stylesheet" href="assets/css/forms.css">
+    <link rel="stylesheet" href="assets/css/footer.css">
+    <link rel="stylesheet" href="assets/css/faq.css">
+    <link rel="stylesheet" href="assets/css/pricing.css">
+    <link rel="stylesheet" href="assets/css/equip.css">
+    <link rel="stylesheet" href="assets/css/sections.css">
+    <link rel="stylesheet" href="assets/css/hardware-nav.css" />
+    <link rel="stylesheet" href="assets/css/utilities.css">
+    <link rel="stylesheet" href="https://unpkg.com/swiper@8/swiper-bundle.min.css" />
+    <link rel="stylesheet" href="assets/slick/slick.css">
+    <link rel="stylesheet" href="assets/slick/slick-theme.css">
+    <link rel="stylesheet" href="assets/css/burger.css">
+    <link rel="stylesheet" href="assets/css/fixes.css">
+    <script src="assets/js/i18n.js"></script>
+    <script defer src="assets/js/i18n-components.js"></script>
+    <script defer src="components/language_switcher.js"></script>
+    <script src="components/top_menu.js"></script>
+    <script src="components/faq.js"></script>
+    <script src="components/bottom_menu.js"></script>
+    <style>
+        .policy-content {
+            margin: 50pt 128pt 20pt 128pt;
+        }
+
+        .policy-content h1 {
+            margin-top: 0;
+            margin-bottom: 20pt;
+            text-align: center;
+        }
+
+        .policy-content h2 {
+            margin-top: 25pt;
+            margin-bottom: 10pt;
+        }
+
+        .policy-content p,
+        .policy-content li {
+            margin-bottom: 10pt;
+            line-height: 1.55;
+        }
+
+        .policy-content ul {
+            padding-left: 30pt;
+            margin-bottom: 15pt;
+        }
+
+        @media (max-width: 991px) {
+            .policy-content {
+                margin: 40px 40px;
+            }
+        }
+
+        @media (max-width: 480px) {
+            .policy-content {
+                margin: 30px 20px;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <top-menu></top-menu>
+    <div class="wrapper">
+        <div class="text policy-content">
+            <h1>Slimrate SMS Terms and Conditions</h1>
+
+            <p><strong>Effective Date:</strong> May 20, 2026</p>
+            <p><strong>Program Name:</strong> Slimrate SMS Communications</p>
+
+            <p>
+                By opting into SMS communications from Slimrate, you agree to receive text messages from Slimrate, LLC
+                related to your account, customer support, appointments, payment processing updates, service notifications,
+                and promotional communications.
+            </p>
+
+            <h2>1. Opt-In and Consent</h2>
+            <p>
+                You may opt in by providing your phone number and confirming SMS consent through Slimrate checkout flows,
+                account or profile creation, digital or paper authorization forms, support or onboarding calls, website
+                contact forms, merchant application submissions, or appointment and demo scheduling forms.
+            </p>
+            <p>
+                Consent to receive SMS messages is not a condition of purchase.
+            </p>
+
+            <h2>2. Message Frequency</h2>
+            <p>
+                Message frequency may vary depending on your account activity, service usage, appointments, support
+                requests, and selected communication preferences.
+            </p>
+
+            <h2>3. Message and Data Rates</h2>
+            <p>
+                Message and data rates may apply. Message delivery is subject to your mobile carrier and network availability.
+            </p>
+
+            <h2>4. Opt-Out and Help</h2>
+            <p>
+                <strong>Reply STOP to unsubscribe at any time.</strong> After you send STOP, you may receive one final
+                confirmation message and will no longer receive SMS messages from that program unless you opt in again.
+            </p>
+            <p>
+                <strong>Reply HELP for assistance.</strong> You may also contact Slimrate support by email at
+                <a href="mailto:info@slimrate.com">info@slimrate.com</a> or by phone at
+                <a href="tel:8889774533">(888) 977-4533</a>.
+            </p>
+
+            <h2>5. Privacy</h2>
+            <p>
+                Your use of Slimrate SMS communications is also governed by our
+                <a href="privacy-policy.html">Privacy Policy</a>. Mobile information will not be shared, sold, or rented
+                to third parties for their marketing or promotional purposes.
+            </p>
+
+            <h2>6. Carrier Liability</h2>
+            <p>
+                Carriers are not liable for delayed or undelivered messages.
+            </p>
+
+            <h2>7. Changes to These Terms</h2>
+            <p>
+                We may update these SMS Terms and Conditions from time to time. Updates will be posted on this page with a
+                revised effective date.
+            </p>
+        </div>
+        <mini-faq></mini-faq>
+        <bottom-menu></bottom-menu>
+    </div>
+
+    <script src="https://unpkg.com/imask"></script>
+    <script src="assets/js/masks.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="assets/slick/slick.min.js"></script>
+    <script src="assets/js/more.js"></script>
+    <script src="components/zendesk_widget.js"></script>
+    <script src="components/cookie_consent.js"></script>
+    <cookie-consent></cookie-consent>
+</body>
+
+</html>

--- a/docs/sms-terms.html
+++ b/docs/sms-terms.html
@@ -117,7 +117,7 @@
             <p>
                 By opting into SMS communications from Slimrate, you agree to receive text messages from Slimrate, LLC
                 related to your account, customer support, appointments, payment processing updates, service notifications,
-                and promotional communications.
+                and other service communications.
             </p>
 
             <h2>1. Opt-In and Consent</h2>


### PR DESCRIPTION
Adds a public SMS Terms and Conditions page for Twilio A2P registration and links it from the footer.\n\nThe target public URL after GitHub Pages deploy is https://slimrate.com/sms-terms.html.